### PR TITLE
Add size tracking integration and tools for MCP server

### DIFF
--- a/src/mcp_server/stats/INTEGRATION_GUIDE.md
+++ b/src/mcp_server/stats/INTEGRATION_GUIDE.md
@@ -1,0 +1,202 @@
+# MCP Size Tracking Integration Guide
+
+## Quick Start
+
+### 1. Add to your MCP server
+
+```python
+from mcp.server.fastmcp import FastMCP
+from mcp_size_tracker import SizeTracker, track_size
+from typing import Dict, Any, Optional
+
+# Initialize
+mcp = FastMCP("KDB-X")
+tracker = SizeTracker("kdbx_mcp_size_log.json")
+
+
+@mcp.tool()
+@track_size(tracker, "kdbx_run_sql_query")
+async def kdbx_run_sql_query(query: str) -> Dict[str, Any]:
+    """Execute a SQL SELECT query against KDB-X tables."""
+    return await run_query_impl(sqlSelectQuery=query)
+
+
+@mcp.tool()
+@track_size(tracker, "kdbx_similarity_search")
+async def kdbx_similarity_search(
+    table_name: str,
+    query: str,
+    n: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Perform vector similarity search on a KDB-X table."""
+    return await kdbx_similarity_search_impl(table_name, query, n)
+```
+
+### 2. Alternative: Manual tracking
+
+```python
+@mcp.tool()
+async def kdbx_run_sql_query(query: str) -> Dict[str, Any]:
+    """Execute a SQL SELECT query against KDB-X tables."""
+    import time
+    start = time.time()
+
+    result = await run_query_impl(sqlSelectQuery=query)
+
+    duration_ms = (time.time() - start) * 1000
+    tracker.log_call("kdbx_run_sql_query", {"query": query}, result, duration_ms)
+
+    return result
+```
+
+## Viewing Statistics
+
+### Basic usage
+
+```bash
+python view_stats.py
+```
+
+### Filter by date
+
+```bash
+python view_stats.py --since 2026-02-01
+```
+
+### Filter by tool
+
+```bash
+python view_stats.py --tool kdbx_run_sql_query
+```
+
+### Show detailed logs
+
+```bash
+python view_stats.py --detail
+```
+
+## Log File Format
+
+The tracker creates `kdbx_mcp_size_log.json` with entries like:
+
+```json
+[
+  {
+    "timestamp": "2026-02-16T04:30:15.123456",
+    "tool": "kdbx_run_sql_query",
+    "query_size_mb": 0.00015,
+    "response_size_mb": 2.45,
+    "duration_ms": 234,
+    "query_summary": {
+      "query": "SELECT sym, price, size FROM trade WHERE date = 2026-02-16 LIMIT 100"
+    }
+  },
+  {
+    "timestamp": "2026-02-16T04:31:02.654321",
+    "tool": "kdbx_similarity_search",
+    "query_size_mb": 0.00008,
+    "response_size_mb": 0.87,
+    "duration_ms": 312,
+    "query_summary": {
+      "table_name": "news_embeddings",
+      "query": "federal reserve interest rate decision",
+      "n": 10
+    }
+  }
+]
+```
+
+## Adding Custom Tracking
+
+For non-MCP usage, use the tracker directly:
+
+```python
+from mcp_size_tracker import SizeTracker
+
+tracker = SizeTracker("my_log.json")
+
+query = "SELECT sym, price FROM trade WHERE date = 2026-02-16"
+response = await kdbx_run_sql_query(query)
+
+tracker.log_call("kdbx_run_sql_query", {"query": query}, response)
+
+# Get stats
+stats = tracker.get_stats(since_date="2026-02-16T00:00:00")
+print(f"Total response data: {stats['total_response_mb']:.2f} MB")
+```
+
+## Monitoring Best Practices
+
+1. **Rotate logs periodically** - Archive old logs to prevent file growth
+2. **Set alerts** - Monitor for unusually large responses
+3. **Track trends** - Compare daily/weekly totals
+4. **Optimize queries** - Use aggregations and LIMIT clauses to reduce response sizes
+
+## Log Rotation Script
+
+```python
+from pathlib import Path
+from datetime import datetime, timedelta
+import json
+import shutil
+
+def rotate_logs(log_file="mcp_size_log.json", keep_days=30):
+    log_path = Path(log_file)
+    if not log_path.exists():
+        return
+
+    # Archive current log
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_path = log_path.parent / f"{log_path.stem}_{timestamp}.json"
+    shutil.copy(log_path, archive_path)
+
+    # Keep only recent entries
+    with open(log_path) as f:
+        logs = json.load(f)
+
+    cutoff = datetime.now() - timedelta(days=keep_days)
+    cutoff_str = cutoff.isoformat()
+
+    recent = [l for l in logs if l["timestamp"] >= cutoff_str]
+
+    with open(log_path, 'w') as f:
+        json.dump(recent, f, indent=2)
+
+    print(f"Archived {len(logs) - len(recent)} old entries")
+```
+
+## Example Output
+
+```text
+================================================================================
+MCP API CALL SIZE SUMMARY
+================================================================================
+Total calls: 145
+Date range: 2026-02-10 to 2026-02-16
+
+BY TOOL:
+--------------------------------------------------------------------------------
+
+kdbx_run_sql_query:
+  Calls:            128
+  Total Query:      18.45 KB
+  Total Response:   245.67 MB
+  Avg Response:     1.92 MB
+  Max Response:     15.34 MB
+  Avg Duration:     156 ms
+
+kdbx_similarity_search:
+  Calls:            17
+  Total Query:      2.31 KB
+  Total Response:   8.12 MB
+  Avg Response:     489.41 KB
+  Max Response:     1.23 MB
+  Avg Duration:     312 ms
+
+================================================================================
+OVERALL TOTALS:
+  Total Query Data:    20.76 KB
+  Total Response Data: 253.79 MB
+  Combined:            253.81 MB
+================================================================================
+```

--- a/src/mcp_server/stats/__init__.py
+++ b/src/mcp_server/stats/__init__.py
@@ -1,0 +1,5 @@
+from mcp_server.stats.mcp_size_tracker import SizeTracker, track_size
+
+tracker = SizeTracker("insights_mcp_size_log.json")
+
+__all__ = ["SizeTracker", "track_size", "tracker"]

--- a/src/mcp_server/stats/mcp_size_tracker.py
+++ b/src/mcp_server/stats/mcp_size_tracker.py
@@ -1,0 +1,155 @@
+"""
+Size tracking middleware for MCP server responses
+Tracks get_data and get_meta API call sizes in MB
+"""
+
+import sys
+import json
+from datetime import datetime
+from pathlib import Path
+import logging
+
+class SizeTracker:
+    def __init__(self, log_file="kdbx_mcp_size_log.json"):
+        self.log_file = Path(log_file)
+        self.logger = logging.getLogger("kdbx_mcp_size_tracker")
+        
+    def get_size_mb(self, data):
+        """Calculate size of data in MB"""
+        if isinstance(data, str):
+            size_bytes = len(data.encode('utf-8'))
+        elif isinstance(data, (dict, list)):
+            size_bytes = len(json.dumps(data, default=str).encode('utf-8'))
+        else:
+            size_bytes = sys.getsizeof(data)
+        return size_bytes / (1024 * 1024)  # Convert to MB
+    
+    def log_call(self, tool_name, query, response, duration_ms=None):
+        """Log API call with size metrics"""
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "tool": tool_name,
+            "query_size_mb": self.get_size_mb(query),
+            "response_size_mb": self.get_size_mb(response),
+            "duration_ms": duration_ms,
+            "query_summary": self._summarize_query(query)
+        }
+        
+        # Append to log file
+        try:
+            if self.log_file.exists():
+                with open(self.log_file, 'r') as f:
+                    logs = json.load(f)
+            else:
+                logs = []
+            
+            logs.append(entry)
+            
+            with open(self.log_file, 'w') as f:
+                json.dump(logs, f, indent=2)
+                
+        except Exception as e:
+            self.logger.error(f"Failed to log size: {e}")
+        
+        return entry
+    
+    def _summarize_query(self, query):
+        """Create a brief summary of the query parameters"""
+        if isinstance(query, dict):
+            # Create a compact summary of all parameters
+            summary = {}
+            for key, value in query.items():
+                # Truncate long string values
+                if isinstance(value, str) and len(value) > 100:
+                    summary[key] = value[:100] + "..."
+                # Summarize lists/dicts
+                elif isinstance(value, (list, dict)):
+                    summary[key] = f"<{type(value).__name__} len={len(value)}>"
+                else:
+                    summary[key] = value
+            return summary
+        # Fallback for non-dict queries
+        return str(query)[:100]
+    
+    def get_stats(self, since_date=None):
+        """Get aggregated statistics"""
+        if not self.log_file.exists():
+            return {"total_calls": 0, "total_response_mb": 0}
+        
+        with open(self.log_file, 'r') as f:
+            logs = json.load(f)
+        
+        if since_date:
+            logs = [l for l in logs if l["timestamp"] >= since_date]
+        
+        stats = {
+            "total_calls": len(logs),
+            "total_query_mb": sum(l["query_size_mb"] for l in logs),
+            "total_response_mb": sum(l["response_size_mb"] for l in logs),
+            "by_tool": {}
+        }
+        
+        for log in logs:
+            tool = log["tool"]
+            if tool not in stats["by_tool"]:
+                stats["by_tool"][tool] = {
+                    "calls": 0,
+                    "total_response_mb": 0,
+                    "avg_response_mb": 0
+                }
+            stats["by_tool"][tool]["calls"] += 1
+            stats["by_tool"][tool]["total_response_mb"] += log["response_size_mb"]
+        
+        # Calculate averages
+        for tool, data in stats["by_tool"].items():
+            data["avg_response_mb"] = data["total_response_mb"] / data["calls"]
+        
+        return stats
+
+
+# Decorator for tracking tool calls
+def track_size(tracker, tool_name):
+    """Decorator to track size of tool calls"""
+    from functools import wraps
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            import time
+            import inspect
+            start = time.time()
+
+            # Capture all input parameters (more generic than just 'query')
+            sig = inspect.signature(func)
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+            input_params = dict(bound_args.arguments)
+
+            # Execute the actual tool
+            response = await func(*args, **kwargs)
+
+            duration_ms = (time.time() - start) * 1000
+
+            # Log the call
+            tracker.log_call(tool_name, input_params, response, duration_ms)
+
+            return response
+        return wrapper
+    return decorator
+
+
+# Example integration with your MCP server
+"""
+from mcp.server.fastmcp import FastMCP
+from mcp_size_tracker import SizeTracker, track_size
+
+mcp = FastMCP("KDB-X")
+tracker = SizeTracker("kdbx_mcp_size_log.json")
+
+@mcp.tool()
+@track_size(tracker, "kdbx_run_sql_query")
+async def kdbx_run_sql_query(query: str) -> str:
+    # Your existing implementation
+    result = kx_client.getData(query)
+    return result
+"""

--- a/src/mcp_server/stats/rotate_logs.py
+++ b/src/mcp_server/stats/rotate_logs.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3 
+from pathlib import Path
+from datetime import datetime, timedelta
+import json
+import argparse
+import shutil
+
+def rotate_logs(log_file="mcp_size_log.json", keep_days=30):
+    log_path = Path(log_file)
+    if not log_path.exists():
+        return
+    
+    # Archive current log
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    archive_path = log_path.parent / f"{log_path.stem}_{timestamp}.json"
+    shutil.copy(log_path, archive_path)
+    
+    # Keep only recent entries
+    with open(log_path) as f:
+        logs = json.load(f)
+    
+    cutoff = datetime.now() - timedelta(days=keep_days)
+    cutoff_str = cutoff.isoformat()
+    
+    recent = [l for l in logs if l["timestamp"] >= cutoff_str]
+    
+    with open(log_path, 'w') as f:
+        json.dump(recent, f, indent=2)
+    
+    print(f"Archived {len(logs) - len(recent)} old entries")
+
+def main():
+    parser = argparse.ArgumentParser(description="Trim MCP size tracking stats log")
+    parser.add_argument("--log-file", default="mcp_size_log.json", help="Log file path")
+    parser.add_argument("--keep-days", default=7, type=int, help="Number of days to keep")
+    args = parser.parse_args()
+
+    rotate_logs(args.log_file, args.keep_days)
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server/stats/view_stats.py
+++ b/src/mcp_server/stats/view_stats.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+View MCP size tracking statistics
+Usage: python view_stats.py [--since YYYY-MM-DD] [--tool TOOL_NAME]
+"""
+
+import json
+import argparse
+from pathlib import Path
+
+def format_mb(mb):
+    """Format MB size"""
+    if mb < 1:
+        return f"{mb*1024:.2f} KB"
+    return f"{mb:.2f} MB"
+
+def main():
+    parser = argparse.ArgumentParser(description="View MCP size tracking stats")
+    parser.add_argument("--log-file", default="mcp_size_log.json", help="Log file path")
+    parser.add_argument("--since", help="Filter since date (YYYY-MM-DD)")
+    parser.add_argument("--tool", help="Filter by tool name")
+    parser.add_argument("--detail", action="store_true", help="Show detailed logs")
+    args = parser.parse_args()
+    
+    log_path = Path(args.log_file)
+    if not log_path.exists():
+        print(f"No log file found at {log_path}")
+        return
+    
+    with open(log_path) as f:
+        logs = json.load(f)
+    
+    # Apply filters
+    if args.since:
+        since_dt = f"{args.since}T00:00:00"
+        logs = [l for l in logs if l["timestamp"] >= since_dt]
+    
+    if args.tool:
+        logs = [l for l in logs if l["tool"] == args.tool]
+    
+    if not logs:
+        print("No matching logs found")
+        return
+    
+    # Summary stats
+    print("=" * 80)
+    print("MCP API CALL SIZE SUMMARY")
+    print("=" * 80)
+    print(f"Total calls: {len(logs)}")
+    print(f"Date range: {logs[0]['timestamp'][:10]} to {logs[-1]['timestamp'][:10]}")
+    print()
+    
+    # Aggregate by tool
+    by_tool = {}
+    for log in logs:
+        tool = log["tool"]
+        if tool not in by_tool:
+            by_tool[tool] = {
+                "calls": 0,
+                "total_query_mb": 0,
+                "total_response_mb": 0,
+                "max_response_mb": 0,
+                "total_duration_ms": 0
+            }
+        by_tool[tool]["calls"] += 1
+        by_tool[tool]["total_query_mb"] += log["query_size_mb"]
+        by_tool[tool]["total_response_mb"] += log["response_size_mb"]
+        by_tool[tool]["max_response_mb"] = max(
+            by_tool[tool]["max_response_mb"], 
+            log["response_size_mb"]
+        )
+        if log.get("duration_ms"):
+            by_tool[tool]["total_duration_ms"] += log["duration_ms"]
+    
+    # Print per-tool stats
+    print("BY TOOL:")
+    print("-" * 80)
+    for tool, stats in sorted(by_tool.items()):
+        avg_response = stats["total_response_mb"] / stats["calls"]
+        avg_duration = stats["total_duration_ms"] / stats["calls"] if stats["total_duration_ms"] > 0 else 0
+        
+        print(f"\n{tool}:")
+        print(f"  Calls:            {stats['calls']}")
+        print(f"  Total Query:      {format_mb(stats['total_query_mb'])}")
+        print(f"  Total Response:   {format_mb(stats['total_response_mb'])}")
+        print(f"  Avg Response:     {format_mb(avg_response)}")
+        print(f"  Max Response:     {format_mb(stats['max_response_mb'])}")
+        if avg_duration > 0:
+            print(f"  Avg Duration:     {avg_duration:.0f} ms")
+    
+    # Overall totals
+    total_query = sum(s["total_query_mb"] for s in by_tool.values())
+    total_response = sum(s["total_response_mb"] for s in by_tool.values())
+    
+    print("\n" + "=" * 80)
+    print("OVERALL TOTALS:")
+    print(f"  Total Query Data:    {format_mb(total_query)}")
+    print(f"  Total Response Data: {format_mb(total_response)}")
+    print(f"  Combined:            {format_mb(total_query + total_response)}")
+    print("=" * 80)
+    
+    # Detailed logs if requested
+    if args.detail:
+        print("\nDETAILED LOGS:")
+        print("-" * 80)
+        for log in logs[-20:]:  # Last 20 entries
+            print(f"\n{log['timestamp']}")
+            print(f"  Tool:     {log['tool']}")
+            print(f"  Query:    {format_mb(log['query_size_mb'])}")
+            print(f"  Response: {format_mb(log['response_size_mb'])}")
+            if log.get('query_summary'):
+                print(f"  Summary:  {log['query_summary']}")
+            if log.get('duration_ms'):
+                print(f"  Duration: {log['duration_ms']:.0f} ms")
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server/tools/kdbx_run_sql_query.py
+++ b/src/mcp_server/tools/kdbx_run_sql_query.py
@@ -2,6 +2,7 @@ import logging
 import pykx as kx
 import json
 from typing import Dict, Any
+from mcp_server.utils.kdbx import get_kdb_connection
 from mcp_server.stats import tracker, track_size
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_server/tools/kdbx_run_sql_query.py
+++ b/src/mcp_server/tools/kdbx_run_sql_query.py
@@ -2,7 +2,7 @@ import logging
 import pykx as kx
 import json
 from typing import Dict, Any
-from mcp_server.utils.kdbx import get_kdb_connection
+from mcp_server.stats import tracker, track_size
 
 logger = logging.getLogger(__name__)
 MAX_ROWS_RETURNED = 1000
@@ -50,6 +50,7 @@ async def run_query_impl(sqlSelectQuery: str) -> Dict[str, Any]:
 
 def register_tools(mcp_server):
     @mcp_server.tool()
+    @track_size(tracker, "kdbx_run_sql_query")
     async def kdbx_run_sql_query(query: str) -> Dict[str, Any]:
         """
         Execute a SQL query and return structured results only to be used on kdb and not on kdbai.

--- a/src/mcp_server/tools/kdbx_sim_search.py
+++ b/src/mcp_server/tools/kdbx_sim_search.py
@@ -7,7 +7,7 @@ from mcp_server.utils.kdbx import get_kdb_connection
 from mcp_server.utils.embeddings import get_provider
 from mcp_server.utils.format_utils import normalize_search_result
 from mcp_server.utils.embeddings_helpers import get_embedding_config
-
+from mcp_server.stats import tracker, track_size
 
 config = KDBConfig()
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ async def kdbx_similarity_search_impl(table_name: str,
                                     vecs:?[tbl;enlist (=;.Q.pf;d);0b;(enlist c)!enlist c]c;
                                     if[not count vecs; :()];
                                     res:.ai.flat.search[vecs;args`qvec;args`n;args`metric];
-                                    res:res@\:iasc res[1];
+                                    res:res@\\:iasc res[1];
                                     `dist xcols update dist:res[0] from ?[tbl;((=;.Q.pf;d);(in;`i;res[1]));0b;()]
                                 }[;args;get args`table;c] each .Q.pv;
                                 ![(args`n)#`dist xdesc res;();0b;enlist c]
@@ -118,7 +118,7 @@ async def kdbx_hybrid_search_impl(table_name: str,
                                     vecs:?[tbl;enlist (=;.Q.pf;d);0b;(enlist c)!enlist c]c;
                                     if[not count vecs; :()];
                                     res:.ai.flat.search[vecs;args`dense;args`n;args`metric];
-                                    res:res@\:iasc res[1];
+                                    res:res@\\:iasc res[1];
                                     `dist`id xcols update dist:res[0],id:((0,neg[1]_sums[.Q.cn[tbl]])@.Q.pv?/:d)+res[1] from ?[tbl;((=;.Q.pf;d);(in;`i;res[1]));0b;()]
                                 }[;args;get args`table;c] each .Q.pv;
                                 rdense:![(args`n)#`dist xdesc rdense;();0b;enlist c];
@@ -176,6 +176,7 @@ def register_tools(mcp_server):
         return []
     
     @mcp_server.tool()
+    @track_size(tracker, "kdbx_similarity_search")
     async def kdbx_similarity_search(table_name: str,
                                         query: str,
                                         n: Optional[int] = None) -> Dict[str, Any]:
@@ -198,6 +199,7 @@ def register_tools(mcp_server):
         return results
     
     @mcp_server.tool()
+    @track_size(tracker, "kdbx_hybrid_search")
     async def kdbx_hybrid_search(table_name: str,
                                     query: str,
                                     n: Optional[int] = None) -> Dict[str, Any]:


### PR DESCRIPTION
- Introduced `SizeTracker` for logging API call sizes and durations.
- Added integration guide for using size tracking with MCP server tools.
- Implemented log rotation and viewing scripts for size tracking statistics.
- Enhanced `kdbx_run_sql_query` and `kdbx_similarity_search` with size tracking decorators.